### PR TITLE
Added docker support

### DIFF
--- a/client.js
+++ b/client.js
@@ -433,8 +433,8 @@ write-data=${ path.resolve(config.instanceDirectory, instance) }\r\n
 	fs.copySync(path.join(instancedirectory, "instanceMods"), path.join(instancedirectory, "mods"));
 
 	process.on('SIGINT', function () {
-		console.log("Caught interrupt signal, sending /quit");
-		messageInterface("/quit");
+		console.log("Caught interrupt signal, sending ^C");
+		serverprocess.kill("SIGINT");
 	});
 
 	// Spawn factorio server


### PR DESCRIPTION
Docker doesn't really do anything with the  `/quit`.
However, changing from `quit` to `serverprocess.kill("SIGINT");` solved this issue.
The node exits with:
`[dumb-init] Child exited with status 0. Goodbye.`