### PR TITLE
Update to research sync plugin

### DIFF
--- a/sharedPlugins/researchSync/dumpResearch.lua
+++ b/sharedPlugins/researchSync/dumpResearch.lua
@@ -3,7 +3,11 @@
 local data = {};
 
 for _, tech in pairs(game.forces["player"].technologies) do
-    table.insert(data, tech.name .. ":" .. tostring(tech.researched) .. ":" .. tostring(tech.level));
+    if tech.prototype.max_level == 4294967295 then
+        table.insert(data, tech.name .. ":" .. tostring(tech.researched) .. ":" .. tostring(tech.level) .. ":true");
+    else
+        table.insert(data, tech.name .. ":" .. tostring(tech.researched) .. ":" .. tostring(tech.level) .. ":false");
+    end
 end
 
 game.write_file("researchSync.txt", table.concat(data, "\n"), false, 0)

--- a/sharedPlugins/researchSync/enableResearch.lua
+++ b/sharedPlugins/researchSync/enableResearch.lua
@@ -1,14 +1,13 @@
 /silent-command
 if game.forces['player'].technologies['{tech_name}'] then
-	if game.forces['player'].technologies['{tech_name}'].researched ~= {tech_researched} then
-		game.forces['player'].technologies['{tech_name}'].researched = {tech_researched}
-	end
-	if game.forces['player'].technologies['{tech_name}'].level ~= {tech_level} then
+	if 1 == {tech_infinite} then
 		game.forces['player'].technologies['{tech_name}'].level = {tech_level}
+	else
+		game.forces['player'].technologies['{tech_name}'].researched = true
 	end
     script.raise_event(defines.events.on_research_finished, {research=game.forces['player'].technologies['{tech_name}'], by_script=true})
 	game.play_sound({path="utility/research_completed"})
-    if game.forces['player'].technologies['{tech_name}'].researched == false then
+    if 1 == {tech_infinite} then
 		game.print("Technology {tech_name} synced at level {tech_level}")
 	else
 		game.print("Technology {tech_name} synced")

--- a/sharedPlugins/researchSync/enableResearch.lua
+++ b/sharedPlugins/researchSync/enableResearch.lua
@@ -8,8 +8,8 @@ if game.forces['player'].technologies['{tech_name}'] then
     script.raise_event(defines.events.on_research_finished, {research=game.forces['player'].technologies['{tech_name}'], by_script=true})
 	game.play_sound({path="utility/research_completed"})
     if 1 == {tech_infinite} then
-		game.print("Technology {tech_name} synced at level {tech_level}")
+		game.print("Infinite technology {tech_name} level {tech_level} unlocked")
 	else
-		game.print("Technology {tech_name} synced")
+		game.print("Technology {tech_name} researched")
 	end
 end

--- a/sharedPlugins/researchSync/index.js
+++ b/sharedPlugins/researchSync/index.js
@@ -1,16 +1,16 @@
-const fs = require('fs');
+const fs     = require('fs');
 const needle = require("needle");
 
-
 class ResearchSync {
-    constructor(slaveConfig, messageInterface, extras = {}){
-        this.config = slaveConfig;
+    constructor(slaveConfig, messageInterface, extras = {}) {
+        this.config           = slaveConfig;
         this.messageInterface = messageInterface;
-        this.functions = this.loadFunctions();
-		
+        this.functions        = this.loadFunctions();
+
         this.research = {};
 
-        setInterval(() => {
+        setInterval(
+            () => {
                 this.pollResearch();
                 setTimeout(this.doSync.bind(this), 5000);
             },
@@ -25,11 +25,11 @@ class ResearchSync {
 
     doSync() {
         needle.get(this.config.masterIP + ':' + this.config.masterPort + '/api/slaves', (err, resp, slaveData) => {
-            if (err){
-				this.messageInterface("Unable to post JSON master/api/slaves, master might be unreachable");
-				return false;
-			}
-            if (resp.statusCode !== 200){
+            if (err) {
+                this.messageInterface("Unable to post JSON master/api/slaves, master might be unreachable");
+                return false;
+            }
+            if (resp.statusCode !== 200) {
                 this.messageInterface("got error when calling slaves", resp.statusCode, resp.body);
                 return;
             }
@@ -40,58 +40,72 @@ class ResearchSync {
                 if (slaveData[instanceKey].unique === this.config.unique.toString()) {
                     return;
                 }
-                if (!slaveData[instanceKey].hasOwnProperty('meta') || !slaveData[instanceKey].meta.hasOwnProperty('research')) {
+                if (!slaveData[instanceKey].hasOwnProperty('meta')
+                    || !slaveData[instanceKey].meta.hasOwnProperty('research')
+                ) {
                     return;
                 }
                 let researchList = slaveData[instanceKey].meta.research;
-				if(researchList){
+                if (researchList) {
                     Object.keys(researchList).forEach(researchName => {
-                        if (isNaN(researchList[researchName].researched) || isNaN(researchList[researchName].level) || isNaN(researchList[researchName].infinite)) {
+                        if (
+                            isNaN(researchList[researchName].researched)
+                            || isNaN(researchList[researchName].level)
+                            || isNaN(researchList[researchName].infinite))
+                        {
                             return;
                         }
                         if (needResearch.hasOwnProperty(researchName)) {
-                            if (needResearch[researchName].infinite === 1
-                                && needResearch[researchName].level < parseInt(researchList[researchName].level))
-                            {
+                            if (
+                                needResearch[researchName].infinite === 1
+                                && needResearch[researchName].level < parseInt(researchList[researchName].level)
+                            ) {
                                 needResearch[researchName].level = parseInt(researchList[researchName].level);
-                            } else if (needResearch[researchName].researched === 0
-                                && parseInt(researchList[researchName].researched) === 1)
-                            {
+                            } else if (
+                                needResearch[researchName].researched === 0
+                                && parseInt(researchList[researchName].researched) === 1
+                            ) {
                                 needResearch[researchName].researched = 1
                             }
                         } else {
                             needResearch[researchName] = {
                                 researched: parseInt(researchList[researchName].researched),
-                                level: parseInt(researchList[researchName].level),
-                                infinite: parseInt(researchList[researchName].infinite)
+                                level     : parseInt(researchList[researchName].level),
+                                infinite  : parseInt(researchList[researchName].infinite)
                             };
                         }
                     });
-				}
-			});
+                }
+            });
 
             let difference = this.filterResearchDiff(this.research, needResearch);
 
             Object.keys(difference).forEach((key) => {
                 if (this.research[key]) {
                     let command = this.functions.enableResearch;
-                    while(command.includes("{tech_name}")){
+                    while (command.includes("{tech_name}")) {
                         command = command.replace("{tech_name}", key);
                         command = command.replace("{tech_researched}", difference[key].researched);
                         command = command.replace("{tech_level}", difference[key].level);
                         command = command.replace("{tech_infinite}", difference[key].infinite);
                     }
                     this.messageInterface(command);
-                    console.log('Unlocking '+ key + ': ' + (difference[key].researched === 0 ? 'false' : 'true') + ' and level ' + difference[key].level + ', was '+ (this.research[key].researched === 0 ? 'false' : 'true') + ' at level ' + this.research[key].level);
-                    this.messageInterface("Unlocking research: " + key + " at research state = " + (difference[key].researched === 0 ? 'false' : 'true') + ' and level ' + difference[key].level);
+                    let log_message = '';
+                    if (difference[key].infinite === 1) {
+                        log_message = 'Unlocking infinite research ' + key + 'at level ' + this.research[key].level;
+                    }  else {
+                        log_message = 'Unlocking research ' + key;
+                    }
+                    console.log(log_message);
+                    this.messageInterface(log_message);
                     this.research[key] = difference[key];
                 }
             });
 
             needle.post(this.config.masterIP + ':' + this.config.masterPort + '/api/editSlaveMeta', {
                 instanceID: this.config.unique,
-                password: this.config.clientPassword,
-                meta: {research: this.research}
+                password  : this.config.clientPassword,
+                meta      : {research: this.research}
             }, {headers: {'x-access-token': this.config.masterAuthToken}}, function (err, resp) {
                 // success?
             });
@@ -118,22 +132,23 @@ class ResearchSync {
 
     loadFunctions() {
         return {
-            dumpResearch: this.loadFunc("dumpResearch.lua"),
-			enableResearch: this.loadFunc("enableResearch.lua"),
+            dumpResearch  : this.loadFunc("dumpResearch.lua"),
+            enableResearch: this.loadFunc("enableResearch.lua"),
         };
     }
 
     loadFunc(path) {
-        return fs.readFileSync("sharedPlugins/researchSync/" + path,'utf-8').replace(/\r?\n|\r/g,' ');
+        return fs.readFileSync("sharedPlugins/researchSync/" + path, 'utf-8').replace(/\r?\n|\r/g, ' ');
     }
-    scriptOutput(data){
-        let kv              = data.split(":");
-        let name            = kv[0];
-        let researched      = ('true' !== kv[1]
+
+    scriptOutput(data) {
+        let kv         = data.split(":");
+        let name       = kv[0];
+        let researched = ('true' !== kv[1]
             ? 0
             : 1);
-        let level           = parseInt(kv[2]);
-        let infinite        = ('true' !== kv[3]
+        let level      = parseInt(kv[2]);
+        let infinite   = ('true' !== kv[3]
             ? 0
             : 1);
         if (!isNaN(level) && !isNaN(researched)) {


### PR DESCRIPTION
- Infinite science proper support - no more sync level by level
- Removed ability to un-research science - it never worked properly outside 2 node cluster, never tested at scale and probably causes current sync loops.
- Improved logging
- Decreased pooling rate for science - no need to do it every 5 seconds - every 30 is enough. Can be overridden by config.