### PR TITLE
added res.sendStatus(200); to stop client errors throwing

### DIFF
--- a/master.js
+++ b/master.js
@@ -362,6 +362,7 @@ app.post("/api/editSlaveMeta", authenticate.middleware, function(req,res) {
 			let metaPortion = JSON.stringify(req.body.meta);
 			if(metaPortion.length > 50) metaPortion = metaPortion.substring(0,20) + "...";
 			// console.log("Updating slave "+slaves[req.body.instanceID].instanceName+": " + slaves[req.body.instanceID].mac + " : " + slaves[req.body.instanceID].serverPort+" at " + slaves[req.body.instanceID].publicIP, metaPortion);
+			res.sendStatus(200);
 		} else {
 			res.send("ERROR: Invalid instanceID or password")
 		}


### PR DESCRIPTION
according to the docs
"The methods on the response object (res) in the following table can send a response to the client, and terminate the request-response cycle. If none of these methods are called from a route handler, the client request will be left hanging."
Last sentence is the critical one.
Sending a status code 200 should fix the issue.
http://expressjs.com/en/guide/routing.html