### PR TITLE
Fix wrong argument order

### DIFF
--- a/sharedPlugins/researchSync/index.js
+++ b/sharedPlugins/researchSync/index.js
@@ -128,7 +128,7 @@ class ResearchSync {
 
     request_cluster_data() {
         const slaves_data_url = `${this.config.masterIP}:${this.config.masterPort}/api/slaves`
-        needle.get(slaves_data_url, this.sync_researches.bind(this), {compressed:true})
+        needle.get(slaves_data_url, {compressed:true}, this.sync_researches.bind(this))
     }
 
     sync_researches(err, resp, slaves_data) {


### PR DESCRIPTION
Fix compression not applying because the order of the callback and
options arguments were swapped in the call to Needle.get for the
request_cluster_data function.