### PR TITLE
Switch to rcon-client fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-factorio-api": "^0.3.1-alpha",
     "node-forge": "^0.7.1",
     "prom-client": "^10.2.3",
-    "rcon-client": "^3.1.6",
+    "rcon-client": "git+https://gitlab.com/Hornwitser/rcon-client.git",
     "request": "^2.83.0",
     "right-pad": "^1.0.1",
     "rmdir-sync": "^1.0.1",


### PR DESCRIPTION
Switch to using fork of rcon-client where the commands and the responses
are not converted to ASCII before being sent over the wire.  Should fix
the issue with Russian text showing up as garbled letters in the chat as
well as the issue with train schedules using >= and <= conditions.

If rcon-client upstream is updated with the utf8 patch this commit can
be reverted with the version the patch was included in.