### PR TITLE
Fix broken require in lib/getInstances.js

### DIFF
--- a/lib/getInstances.js
+++ b/lib/getInstances.js
@@ -1,4 +1,4 @@
-const fileOps = require("fileOps");
+const fileOps = require("lib/fileOps");
 // const config = require("./../config");
 
 module.exports = function(config) {


### PR DESCRIPTION
The require change in f76c84c for lib/getInstances.js accidentally left
out the lib/ prefix causing it to break.